### PR TITLE
fix: sidebar profile icon clipped (#10)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,7 @@
         "elevenlabs": "latest",
         "googleapis": "^148.0.0",
         "langchain": "^0.3.21",
-        "lucide-react": "^0.488.0",
+        "lucide-react": "^0.503.0",
         "motion": "^12.7.4",
         "next": "15.2.4",
         "next-themes": "^0.4.6",
@@ -922,7 +922,7 @@
 
     "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="],
 
-    "lucide-react": ["lucide-react@0.488.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ronlL0MyKut4CEzBY/ai2ZpKPxyWO4jUqdAkm2GNK5Zn3Rj+swDz+3lvyAUXN0PNqPKIX6XM9Xadwz/skLs/pQ=="],
+    "lucide-react": ["lucide-react@0.503.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-HGGkdlPWQ0vTF8jJ5TdIqhQXZi6uh3LnNgfZ8MHiuxFfX3RZeA79r2MW2tHAZKlAVfoNE8esm3p+O6VkIvpj6w=="],
 
     "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
 

--- a/components/integration-sidebar.tsx
+++ b/components/integration-sidebar.tsx
@@ -40,6 +40,7 @@ import {
 	PanelRight,
 	Plus,
 	Settings,
+	Merge,
 	X,
 } from "lucide-react";
 import Link from "next/link";
@@ -224,7 +225,7 @@ export function MinimalIntegrationSidebar({ documents = [] as Document[] }) {
 										</SidebarMenuButton>
 									</CollapsibleTrigger>
 									<CollapsibleContent>
-										<ScrollArea className="h-96">
+										<ScrollArea className="max-h-70 h-auto">
 											<div className="space-y-1">
 												<div className="sticky ml-4 top-0 border-border border-l border-dashed px-2 group-data-[collapsible=icon]:ml-0 group-data-[collapsible=icon]:px-0">
 													{isCreatingDoc ? (
@@ -370,13 +371,14 @@ export function MinimalIntegrationSidebar({ documents = [] as Document[] }) {
 													)}
 												</div>
 											))}
-											<div className="px-1">
+											<div>
 												<SidebarMenuButton
 													asChild
 													tooltip="View all integrations"
 													className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 font-medium text-primary brightness-150 text-sm hover:bg-muted group-data-[collapsible=icon]:justify-center"
 												>
 													<Link href="/integrations">
+													<Merge className="h-4 w-4 shrink-0" />
 														<span className="truncate group-data-[collapsible=icon]:hidden">
 															View all integrations
 														</span>

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"elevenlabs": "latest",
 		"googleapis": "^148.0.0",
 		"langchain": "^0.3.21",
-		"lucide-react": "^0.488.0",
+		"lucide-react": "^0.503.0",
 		"motion": "^12.7.4",
 		"next": "15.2.4",
 		"next-themes": "^0.4.6",


### PR DESCRIPTION
### What this PR does

- Fixes #10
- Sidebar profile icon was half hidden off-screen.
- Adjusted sidebar layout, padding, and overflow so the icon is fully visible on all viewports.
![Screenshot 2025-04-24 190633](https://github.com/user-attachments/assets/478f7955-05ff-4058-85d1-162768cc27cf)
![Screenshot 2025-04-24 190715](https://github.com/user-attachments/assets/cd4c1495-c4b1-4462-aded-7f2186ac68e5)
![Screenshot 2025-04-24 190725](https://github.com/user-attachments/assets/541eccfc-7e07-490b-a7b6-4aa94e8f6b77)

Also added a missing icon of View All integrations 
ICON :  Merge Icon from lucid React in View All integrations