### PR TITLE
fix: sync AI sidebar open state with the zen mode one

### DIFF
--- a/app/(protected)/docs/[doc_id]/text-editor/index.tsx
+++ b/app/(protected)/docs/[doc_id]/text-editor/index.tsx
@@ -697,16 +697,13 @@ export function TextEditor({
 				)}
 			</div>
 
-			{/* AI Chat Sidebar - Only show when not in Zen mode */}
-			{!isZenMode && (
-				<div className="group/sidebar-wrapper has-[data-side=right]:ml-0">
-					<AIChatSidebar
-						content={input}
-						isEnabled={isAutocompleteEnabled}
-						onPendingUpdate={setPendingUpdate}
-					/>
-				</div>
-			)}
+			<div className="group/sidebar-wrapper has-[data-side=right]:ml-0">
+				<AIChatSidebar
+					content={input}
+					isEnabled={isAutocompleteEnabled}
+					onPendingUpdate={setPendingUpdate}
+				/>
+			</div>
 
 			{/* Text Selection Menu */}
 			{selectedText && selectionPosition && !isZenMode && (

--- a/app/(protected)/docs/[doc_id]/text-editor/index.tsx
+++ b/app/(protected)/docs/[doc_id]/text-editor/index.tsx
@@ -42,7 +42,6 @@ export function TextEditor({
 	const [cursorPosition, setCursorPosition] = React.useState(0);
 	const [isAutocompleteEnabled, setIsAutocompleteEnabled] =
 		React.useState(true);
-	const [isAIChatOpen, setIsAIChatOpen] = React.useState(true);
 	const [isZenMode, setIsZenMode] = React.useState(false);
 
 	const [updatedAt, setUpdatedAt] = React.useState(initialUpdatedAt);
@@ -155,7 +154,6 @@ export function TextEditor({
 				e.preventDefault();
 				setIsZenMode((prev) => !prev);
 				if (!isZenMode) {
-					setIsAIChatOpen(false);
 					// Request full screen when entering zen mode
 					document.documentElement.requestFullscreen().catch((err) => {
 						console.log("Error attempting to enable full-screen mode:", err);
@@ -457,8 +455,7 @@ export function TextEditor({
 				id={TOUR_STEP_IDS.TEXT_EDITOR}
 				className={cn(
 					"relative flex flex-1 flex-col",
-					!isAIChatOpen && "pr-0",
-					isZenMode && "fixed inset-0 z-50 bg-background/95",
+					isZenMode ? "fixed inset-0 z-50 bg-background/95" : "pr-0",
 				)}
 			>
 				{/* Decorative gradients - only show when modifying */}
@@ -660,7 +657,6 @@ export function TextEditor({
 											onClick={() => {
 												setIsZenMode((prev) => !prev);
 												if (!isZenMode) {
-													setIsAIChatOpen(false);
 													// Request full screen when clicking the button
 													document.documentElement
 														.requestFullscreen()
@@ -702,7 +698,7 @@ export function TextEditor({
 			</div>
 
 			{/* AI Chat Sidebar - Only show when not in Zen mode */}
-			{isAIChatOpen && !isZenMode && (
+			{!isZenMode && (
 				<div className="group/sidebar-wrapper has-[data-side=right]:ml-0">
 					<AIChatSidebar
 						content={input}

--- a/app/(protected)/home/page.tsx
+++ b/app/(protected)/home/page.tsx
@@ -64,7 +64,7 @@ export default async function HomePage() {
 		.slice(0, 5); // Limit to 5 most recent items
 
 	return (
-		<div className="flex h-screen flex-col bg-background text-foreground">
+		<div className="flex h-full flex-col bg-background text-foreground">
 			<HomeTour />
 			{/* Main Content */}
 			<main className="flex flex-1 items-center justify-center overflow-auto">


### PR DESCRIPTION
Close #25 

I saw that the independent useState for ai chat sidebar was only been set when zen mode changes, so I synced both by using only the zen mode state. Please tell me if you think is the right choice or if I missed some edge case.

PD: I added a small change in the css home editor to remove an unwanted scrollbar when announcement bar was opened, I can raise an issue about that and separate from this PR if you want

![image](https://github.com/user-attachments/assets/e1a9fee1-c63a-46fe-82bf-79b721b069dd)
